### PR TITLE
update Swagger version and change CDN provider

### DIFF
--- a/swagger-ui.html
+++ b/swagger-ui.html
@@ -1,38 +1,40 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-    <meta charset="UTF-8">
-    <title>ServiceDesk Service Swagger</title>
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3.12.1/swagger-ui.css">
 
+<head>
+  <meta charset="UTF-8">
+  <title>Swagger UI</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3.45.1/swagger-ui.css">
 
 </head>
+
 <body>
 
-<div id="swagger-ui"></div>
+  <div id="swagger-ui"></div>
 
-<script src="https://unpkg.com/swagger-ui-dist@3.12.1/swagger-ui-standalone-preset.js"></script>
-<script src="https://unpkg.com/swagger-ui-dist@3.12.1/swagger-ui-bundle.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3.45.1/swagger-ui-standalone-preset.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3.45.1/swagger-ui-bundle.js"></script>
 
-<script>
+  <script>
+    window.onload = function () {
+      // Build a system
+      const ui = SwaggerUIBundle({
+        url: "<enter url to swagger.json here>",
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout",
+      })
 
-    window.onload = function() {
-        // Build a system
-        const ui = SwaggerUIBundle({
-            url: "<enter url to swagger.json here>",
-            dom_id: '#swagger-ui',
-            deepLinking: true,
-            presets: [
-                SwaggerUIBundle.presets.apis,
-                SwaggerUIStandalonePreset
-            ],
-            plugins: [
-                SwaggerUIBundle.plugins.DownloadUrl
-            ],
-            layout: "StandaloneLayout",
-        })
-        window.ui = ui
+      window.ui = ui
     }
-</script>
+  </script>
 </body>
+
 </html>


### PR DESCRIPTION
Update Swagger version to newer version and change CDN provider to jsDelivr because jsDelivr have a great performance in CDN benchmark. See https://www.cdnperf.com/.